### PR TITLE
feat(cartaeditor): add tooltip on quick toolbar icon buttons

### DIFF
--- a/packages/carta-md/src/lib/CartaEditor.svelte
+++ b/packages/carta-md/src/lib/CartaEditor.svelte
@@ -129,6 +129,7 @@
 						<button
 							class="carta-icon"
 							tabindex={index == 0 ? 0 : -1}
+							title={icon.label}
 							aria-label={icon.label}
 							on:click|preventDefault|stopPropagation={() => {
 								carta.input && icon.action(carta.input);


### PR DESCRIPTION
Fix #33 
Add tooltip on quick toolbar icon buttons

<img width="223" alt="image" src="https://github.com/BearToCode/carta/assets/16435155/77b06900-dbeb-4839-bc88-a0084b096241">
