### PR TITLE
Add mimetypes to the file input

### DIFF
--- a/packages/plugin-attachment/src/lib/index.ts
+++ b/packages/plugin-attachment/src/lib/index.ts
@@ -158,6 +158,7 @@ export const attachment = (options: AttachmentExtensionOptions): Plugin => {
 							const input = document.createElement('input');
 							input.type = 'file';
 							input.multiple = true;
+							input.accept = allowedMimeTypes.join(", ");
 
 							input.onchange = (e) => {
 								const files = (e.target as HTMLInputElement)?.files;

--- a/packages/plugin-attachment/src/lib/index.ts
+++ b/packages/plugin-attachment/src/lib/index.ts
@@ -158,7 +158,7 @@ export const attachment = (options: AttachmentExtensionOptions): Plugin => {
 							const input = document.createElement('input');
 							input.type = 'file';
 							input.multiple = true;
-							input.accept = allowedMimeTypes.join(", ");
+							input.accept = allowedMimeTypes.join(', ');
 
 							input.onchange = (e) => {
 								const files = (e.target as HTMLInputElement)?.files;


### PR DESCRIPTION
While working on attachments, i noticed, that the allowedMimeTypes are not reflected in the file input dialog.
So this just adds the allowedMimeTypes to the file input when uploading a attachment, to already limit the available options of files to upload in the file dialog. 