### PR TITLE
update rehype transform plugin: "plugin-code"

### DIFF
--- a/packages/carta-md/src/lib/internal/carta.ts
+++ b/packages/carta-md/src/lib/internal/carta.ts
@@ -18,6 +18,7 @@ import { CustomEvent, type MaybeArray } from './utils';
 import {
 	loadHighlighter,
 	loadDefaultTheme,
+	loadLanguage,
 	type Highlighter,
 	type GrammarRule,
 	type ShikiOptions,
@@ -43,8 +44,8 @@ export type Listener<K extends CartaEventType | keyof HTMLElementEventMap> = [
 		ev: K extends CartaEventType
 			? Event
 			: K extends keyof HTMLElementEventMap
-			  ? HTMLElementEventMap[K]
-			  : Event
+				? HTMLElementEventMap[K]
+				: Event
 	) => unknown,
 	options?: boolean | AddEventListenerOptions
 ];
@@ -231,6 +232,10 @@ export class Carta {
 			this.mHighlighter = await this.mHighlighter;
 		}
 		return this.mHighlighter;
+	}
+
+	public loadHighlighterLanguage(highlighter: Highlighter, lang: string): Promise<boolean> {
+		return loadLanguage(highlighter, lang, /* loadedLanguages */ undefined);
 	}
 
 	private elementsToBind: {
@@ -465,7 +470,7 @@ export class Carta {
 	 * @example
 	 * ```svelte
 	 * <script>
-	 * 	export let carta;
+	 *   export let carta;
 	 * </script>
 	 *
 	 * <div use:carta.bindToCaret>

--- a/packages/plugin-code/package.json
+++ b/packages/plugin-code/package.json
@@ -1,13 +1,17 @@
 {
 	"name": "@cartamd/plugin-code",
+	"version": "4.0.5",
 	"type": "module",
-	"main": "./dist/index.js",
-	"types": "./dist/index.d.ts",
 	"license": "MIT",
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/BearToCode/carta.git"
 	},
+	"files": [
+		"dist"
+	],
+	"main": "./dist/index.js",
+	"types": "./dist/index.d.ts",
 	"exports": {
 		".": "./dist/index.js",
 		"./*.css": "./dist/*.css"
@@ -15,23 +19,20 @@
 	"scripts": {
 		"build": "tsc && tscp"
 	},
+	"dependencies": {
+		"@shikijs/rehype": "^1.4.0"
+	},
 	"devDependencies": {
-		"@shikijs/rehype": "^1.4.0",
+		"@shikijs/core": "^1.6.4",
+		"@types/hast": "^3.0.4",
 		"@types/node": "^18.16.3",
 		"carta-md": "workspace:*",
 		"typescript": "^5.0.4",
-		"typescript-cp": "^0.1.8"
+		"typescript-cp": "^0.1.8",
+		"unified": "^11.0.4"
 	},
 	"peerDependencies": {
 		"carta-md": "^4.0.0"
-	},
-	"files": [
-		"dist"
-	],
-	"version": "4.0.0",
-	"dependencies": {
-		"@shikijs/rehype": "^1.4.0",
-		"unified": "^11.0.4"
 	},
 	"keywords": [
 		"carta",

--- a/packages/plugin-code/src/index.ts
+++ b/packages/plugin-code/src/index.ts
@@ -1,8 +1,11 @@
 import type { DualTheme, Theme, Plugin } from 'carta-md';
-import type { RehypeShikiOptions } from '@shikijs/rehype';
+import type { Root } from 'hast';
+import type { Transformer } from 'unified';
+import type { HighlighterGeneric } from '@shikijs/core';
+import type { RehypeShikiCoreOptions } from '@shikijs/rehype/core';
 import rehypeShikiFromHighlighter from '@shikijs/rehype/core';
 
-export type CodeExtensionOptions = Omit<RehypeShikiOptions, 'theme' | 'themes'> & {
+export type CodeExtensionOptions = Omit<RehypeShikiCoreOptions, 'theme' | 'themes'> & {
 	theme?: Theme | DualTheme;
 };
 
@@ -35,15 +38,69 @@ export const code = (options?: CodeExtensionOptions): Plugin => {
 				async transform({ processor, carta }) {
 					let theme = options?.theme;
 
-					const highlighter = await carta.highlighter();
+					const cartaHighlighter = await carta.highlighter();
 					if (!theme) {
-						theme = highlighter.theme; // Use the theme specified in the highlighter
+						theme = cartaHighlighter.theme; // Use the theme specified in the highlighter
+					}
+
+					// https://github.com/shikijs/shiki/blob/v1.6.4/packages/rehype/src/core.ts#L72
+
+					const rehypeShikiFromHighlighterWrapper = (
+						highlighter: HighlighterGeneric<any, any>,
+						options: RehypeShikiCoreOptions,
+					): Transformer<Root, Root> => {
+						const onError = options?.onError
+
+						if (onError)
+							delete options.onError
+
+						const transformer: Transformer<Root, Root> = rehypeShikiFromHighlighter(highlighter, options);
+
+						const regex = /^.*Language `([^`]+)` not found.*$/
+
+						// @ts-ignore
+						const transformerWrapper: Transformer<Root, Root> = async (tree: Root) => {
+							try {
+								// @ts-ignore
+								transformer(tree)
+							}
+							catch(e: any) {
+								let ignoreError = false
+
+								if ((e instanceof Error) && e?.message) {
+									const match: RegExpExecArray | null = regex.exec(e.message)
+
+									if (match) {
+										// load language into highlighter, then retry
+
+										const lang: string = match[1]
+
+										const updated: boolean = await carta.loadHighlighterLanguage(cartaHighlighter, lang)
+
+										if (updated) {
+											// @ts-ignore
+											transformerWrapper(tree)
+											ignoreError = true
+										}
+									}
+								}
+
+								if (!ignoreError) {
+									if (onError)
+										onError(e)
+									else
+										throw e
+								}
+							}
+						}
+
+						return transformerWrapper
 					}
 
 					if (isSingleTheme(theme)) {
-						processor.use(rehypeShikiFromHighlighter, highlighter, { ...options, theme });
+						processor.use(rehypeShikiFromHighlighterWrapper, cartaHighlighter, { ...options, theme });
 					} else {
-						processor.use(rehypeShikiFromHighlighter, highlighter, { ...options, themes: theme });
+						processor.use(rehypeShikiFromHighlighterWrapper, cartaHighlighter, { ...options, themes: theme });
 					}
 				}
 			}


### PR DESCRIPTION
fix issue #75

---

comments:
* seems to work well.. both SSR and CSR
  - I'm not familiar with remark and rehype.. and their plugin system.. so this may be a naive implementation;<br>feel free to modify
* `@ts-ignore` is used in 3x places
  - I'm not great with Typescript.. passable at best;<br>maybe you can figure out how to massage the type signatures so these aren't needed?

next steps:
* after this was written.. I made the mistake of trying to cleanup the code a little more by adding:
  ```js
    import {isSingleTheme} from 'carta-md'
  ```
* this sent me down a rabbit hole hellscape
  1. all import statements that reference a typescript file (ex: `foo.ts`) needed to be changed
     - from: `import * as foo from './foo'`
     - to: `import * as foo from './foo.js'`
       * which the typescript compiler handles correctly
       * and the resulting javascript includes the `.js` file extension,<br>which [`node.js` requires](https://github.com/nodejs/node/issues/46006) and seems to be [the standard](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import)
  2. outcome:
     - `plugin-code` successfully imports `isSingleTheme` and compiles correctly
     - `vite` is no-longer able to import Svelte components from the package
       * `Unknown file extension '.svelte'`
       * related issues: [1](https://github.com/sveltejs/kit/issues?q=is%3Aissue+%22Unknown+file+extension%22), [2](https://github.com/sveltejs/kit/issues?q=is%3Aissue+ERR_UNKNOWN_FILE_EXTENSION), [3](https://www.google.com/search?q=%22ERR_UNKNOWN_FILE_EXTENSION%22+%22svelte%22)
  3. I played around with every possible way to specify exports in `package.json` and nothing fixed this error
     - which is an error that I encounter all the time, when trying to use Svelte components from `npm`
     - I'm beginning to wonder if it's my version of `node` or something local to my machine,<br>but on the other hand.. many Svelte components from `npm` do work..<br>so if there's some magical export incantation that makes it work, I'd love to know what that is
     - docs: [1](https://kit.svelte.dev/docs/packaging), [2](https://nodejs.org/docs/latest/api/packages.html#package-entry-points)
* would you like me to add another branch that extends this PR branch?..
  - to include these breaking changes
  - so maybe we can put our heads together and figure out how to make it work