### PR TITLE
replace "remark-gemoji" with "remark-emoji"

### DIFF
--- a/packages/plugin-emoji/package.json
+++ b/packages/plugin-emoji/package.json
@@ -33,8 +33,8 @@
 	],
 	"dependencies": {
 		"bezier-easing": "^2.1.0",
-		"node-emoji": "^1.11.0",
-		"remark-gemoji": "^8.0.0"
+		"node-emoji": "^2.1.3",
+		"remark-emoji": "^5.0.0"
 	},
 	"peerDependencies": {
 		"carta-md": "^4.0.0",

--- a/packages/plugin-emoji/src/lib/Emoji.svelte
+++ b/packages/plugin-emoji/src/lib/Emoji.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import type { Carta } from 'carta-md';
 	import { onDestroy, onMount } from 'svelte';
-	import nodeEmoji from 'node-emoji';
+	import * as nodeEmoji from 'node-emoji';
 	import type { TransitionConfig } from 'svelte/transition';
 
 	const cols = 8;
@@ -98,8 +98,8 @@
 		if (!carta.input) return;
 		// Remove slash and filter
 		carta.input.removeAt(colonPosition, filter.length + 1);
-		carta.input.insertAt(colonPosition, ':' + emoji.key + ':');
-		const newPosition = colonPosition + 2 + emoji.key.length;
+		carta.input.insertAt(colonPosition, ':' + emoji.name + ':');
+		const newPosition = colonPosition + 2 + emoji.name.length;
 		carta.input.textarea.setSelectionRange(newPosition, newPosition);
 		carta.input.update();
 	}
@@ -128,7 +128,7 @@
 		{#each emojis as emoji, i}
 			<button
 				class={i === hoveringIndex ? 'carta-active' : ''}
-				title={emoji.key}
+				title={emoji.name}
 				on:click={() => selectEmoji(emoji)}
 				bind:this={emojisElements[i]}
 			>

--- a/packages/plugin-emoji/src/lib/index.ts
+++ b/packages/plugin-emoji/src/lib/index.ts
@@ -1,5 +1,5 @@
 import type { Plugin, ExtensionComponent, GrammarRule, HighlightingRule } from 'carta-md';
-import remarkGemoji from 'remark-gemoji';
+import remarkEmoji from 'remark-emoji';
 import { fade, scale, type TransitionConfig } from 'svelte/transition';
 import Emoji from './Emoji.svelte';
 import BezierEasing from 'bezier-easing';
@@ -14,6 +14,12 @@ export interface EmojiExtensionOptions {
 	 * Custom out transition. See https://svelte.dev/docs#run-time-svelte-transition.
 	 */
 	outTransition?: (node: Element) => TransitionConfig;
+	/**
+	 * Options for the 'remark-emoji' plugin.
+	 */
+	accessible?: boolean;
+	padSpaceAfter?: boolean;
+	emoticon?: boolean;
 }
 
 interface ComponentProps {
@@ -52,7 +58,7 @@ export const emoji = (options?: EmojiExtensionOptions): Plugin => {
 		name: 'emoji',
 		type: 'inline',
 		definition: {
-			match: ':[a-zA-Z_]+:',
+			match: ':(?:\\+1|[-\\w]+):',
 			name: 'markup.emoji.markdown'
 		}
 	} satisfies GrammarRule;
@@ -78,7 +84,7 @@ export const emoji = (options?: EmojiExtensionOptions): Plugin => {
 				execution: 'sync',
 				type: 'remark',
 				transform({ processor }) {
-					processor.use(remarkGemoji);
+					processor.use(remarkEmoji, options);
 				}
 			}
 		],


### PR DESCRIPTION
fix #86

Both the 'Emoji' component (popup dialog) and remark HTML renderer should use the same underlying library of emoji icons ("node-emoji"), which has been updated from v1 (legacy) to v2 (current).