### PR TITLE
Allow control of scroll behavior via CSS

### DIFF
--- a/packages/carta-md/src/lib/MarkdownEditor.svelte
+++ b/packages/carta-md/src/lib/MarkdownEditor.svelte
@@ -139,7 +139,7 @@
 		currentlyScrolling = scrolled;
 		const targetAvbSpace = target.scrollHeight - target.clientHeight;
 
-		target.scrollTo({ top: percentage * targetAvbSpace, behavior: 'smooth' });
+		target.scrollTo({ top: percentage * targetAvbSpace, behavior: 'auto' });
 		clearCurrentlyScrolling();
 	}
 


### PR DESCRIPTION
By using `{ behavior: 'auto' }` the scroll behavior can be controlled via CSS `scroll-behavior` to allow the option of instant vs smooth. https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-behavior

Useful to account for "prefers reduced motion" preference too.