### PR TITLE
Fix / Improve Attachment Handling

### DIFF
--- a/packages/plugin-attachment/src/lib/index.ts
+++ b/packages/plugin-attachment/src/lib/index.ts
@@ -35,7 +35,14 @@ export interface AttachmentExtensionOptions {
 	loadingOverlay?: false | typeof SvelteComponent<{ uploadingFiles: Writable<File[]> }>;
 }
 
-const ImageMimeTypes = ['image/png', 'image/jpeg', 'image/gif', 'image/svg+xml', 'image/webp', 'image/avif'];
+const ImageMimeTypes = [
+	'image/png',
+	'image/jpeg',
+	'image/gif',
+	'image/svg+xml',
+	'image/webp',
+	'image/avif'
+];
 
 /**
  * Carta attachment plugin.
@@ -64,27 +71,27 @@ export const attachment = (options: AttachmentExtensionOptions): Plugin => {
 	async function handleFile(file: File) {
 		if (!allowedMimeTypes.includes(file.type)) return;
 		if (!carta?.input) return;
-		const input = carta.input
+		const input = carta.input;
 		const textarea = input.textarea;
 
 		let pos = input.textarea.selectionStart;
 		const loadingStr = `[Uploading ${file.name}](loading)`;
-		const isImage = ImageMimeTypes.includes(file.type)
+		const isImage = ImageMimeTypes.includes(file.type);
 
 		if (isImage) {
 			// assume images are being inserted as blocks
 			const line = carta.input.getLine();
-			pos = line.end
+			pos = line.end;
 			if (line.value) {
-				input.insertAt(pos, '\n\n')
-				pos +=2
+				input.insertAt(pos, '\n\n');
+				pos += 2;
 			}
-			input.insertAt(pos,  loadingStr + '\n')
+			input.insertAt(pos, loadingStr + '\n');
 			pos += loadingStr.length + 1;
 		} else {
 			// non image attachments are inline (could make multiple into comma separated list or bullets)
 			carta.input.insertAt(pos, loadingStr + ' ');
-			pos += loadingStr.length + 1
+			pos += loadingStr.length + 1;
 		}
 
 		carta.input.update();
@@ -103,9 +110,7 @@ export const attachment = (options: AttachmentExtensionOptions): Plugin => {
 
 		if (!path) return;
 
-		const str = isImage
-			? `![${file.name}](${path})`
-			: `[${file.name}](${path})`;
+		const str = isImage ? `![${file.name}](${path})` : `[${file.name}](${path})`;
 
 		carta.input.insertAt(loadingStrIndex, str);
 		carta.input.update();
@@ -113,19 +118,19 @@ export const attachment = (options: AttachmentExtensionOptions): Plugin => {
 		// update cursor position to account for the string replacement
 		if (input.textarea.selectionStart < loadingStrIndex) {
 			// caret is before the loading string, no change required
-			pos = input.textarea.selectionStart
+			pos = input.textarea.selectionStart;
 		} else if (input.textarea.selectionStart >= loadingStrIndex + str.length) {
 			// caret is after the loading string, adjust position by the difference
-			pos = input.textarea.selectionStart - loadingStr.length + str.length
+			pos = input.textarea.selectionStart - loadingStr.length + str.length;
 		} else if (input.textarea.selectionStart >= loadingStrIndex) {
 			// caret is within the loading string, position it just after
-			pos = loadingStrIndex + str.length + 1
+			pos = loadingStrIndex + str.length + 1;
 		}
 		textarea.setSelectionRange(pos, pos);
 
 		carta.input.history.saveState(textarea.value, textarea.selectionStart);
 
-		return
+		return;
 	}
 
 	function handleDrop(this: HTMLTextAreaElement, e: DragEvent) {

--- a/packages/plugin-attachment/src/lib/index.ts
+++ b/packages/plugin-attachment/src/lib/index.ts
@@ -16,7 +16,7 @@ export interface AttachmentExtensionOptions {
 	/**
 	 * Supported mime types.
 	 *
-	 * @default ['image/png', 'image/jpeg', 'image/gif', 'image/svg+xml'].
+	 * @default ['image/png', 'image/jpeg', 'image/gif', 'image/svg+xml', 'image/webp', 'image/avif'].
 	 */
 	supportedMimeTypes?: string[];
 	/**
@@ -35,7 +35,7 @@ export interface AttachmentExtensionOptions {
 	loadingOverlay?: false | typeof SvelteComponent<{ uploadingFiles: Writable<File[]> }>;
 }
 
-const ImageMimeTypes = ['image/png', 'image/jpeg', 'image/gif', 'image/svg+xml'];
+const ImageMimeTypes = ['image/png', 'image/jpeg', 'image/gif', 'image/svg+xml', 'image/webp', 'image/avif'];
 
 /**
  * Carta attachment plugin.

--- a/packages/plugin-attachment/src/routes/+page.svelte
+++ b/packages/plugin-attachment/src/routes/+page.svelte
@@ -57,6 +57,10 @@
 		padding: 2rem 0 2rem 0;
 	}
 
+	:global(img) {
+		max-width: 50%;
+	}
+
 	/* Responsive main */
 
 	@media screen and (max-width: 640px) {

--- a/packages/plugin-attachment/src/routes/+page.svelte
+++ b/packages/plugin-attachment/src/routes/+page.svelte
@@ -43,6 +43,7 @@
 	:global(.carta-font-code, code) {
 		font-family: 'Fira Code', monospace;
 		font-variant-ligatures: normal;
+		font-size: 1.1rem;
 	}
 
 	:global(input, textarea, button) {

--- a/packages/plugin-attachment/src/routes/+page.svelte
+++ b/packages/plugin-attachment/src/routes/+page.svelte
@@ -11,7 +11,7 @@
 			attachment({
 				async upload(file) {
 					await new Promise((resolve) => setTimeout(resolve, 1_000));
-					return URL.createObjectURL(file)
+					return URL.createObjectURL(file);
 				}
 			})
 		]

--- a/packages/plugin-attachment/src/routes/+page.svelte
+++ b/packages/plugin-attachment/src/routes/+page.svelte
@@ -6,11 +6,12 @@
 	import '$lib/default.css';
 
 	const carta = new Carta({
+		sanitizer: false,
 		extensions: [
 			attachment({
-				async upload() {
+				async upload(file) {
 					await new Promise((resolve) => setTimeout(resolve, 1_000));
-					return 'some-path';
+					return URL.createObjectURL(file)
 				}
 			})
 		]


### PR DESCRIPTION
I found the editor and rendered view always jumped to the bottom after adding any attachment. This prevents it and also makes a few more changes:

* Addition image types added (WEBP & AVIF)
* Images are added as separate lines
* Other links are added inline

It tries to account for the cursor being moved while images are being uploaded so someone could continue editing without the cursor jumping back to the wrong place.

Additional refinements could allow options for how the insertions are handled - inline, comma separated, bullet lists, etc...