### PR TITLE
some fonts have different heights and line spacing causing problems

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ npm i @cartamd/plugin-name
 	:global(.carta-font-code) {
 		font-family: '...', monospace;
 		font-size: 1.1rem;
+		line-height: 1.1rem;
+		letter-spacing: normal;
 	}
 </style>
 ```


### PR DESCRIPTION
I hit misalignment issues with the syntax highlighter and the textarea. The lines in the commit solved the issue.