### PR TITLE
Use diffhtml to update rendered html

### DIFF
--- a/packages/carta-md/package.json
+++ b/packages/carta-md/package.json
@@ -41,6 +41,7 @@
 	"type": "module",
 	"dependencies": {
 		"diff": "^5.2.0",
+		"diffhtml": "1.0.0-beta.30",
 		"esm-env": "^1.0.0",
 		"rehype-stringify": "^10.0.0",
 		"remark-gfm": "^4.0.0",

--- a/packages/carta-md/src/lib/internal/components/Renderer.svelte
+++ b/packages/carta-md/src/lib/internal/components/Renderer.svelte
@@ -9,6 +9,7 @@
 	import type { UIEventHandler } from 'svelte/elements';
 	import { onMount, type Snippet } from 'svelte';
 	import { debounce } from '../utils';
+	import { innerHTML } from 'diffhtml';
 
 	interface Props {
 		/**
@@ -49,10 +50,7 @@
 	const debouncedRenderer = debounce((value: string) => {
 		carta
 			.render(value)
-			.then((rendered) => {
-				renderedHtml = ''; // Force @html to re-render everything
-				renderedHtml = rendered;
-			})
+			.then((rendered) => renderedHtml = rendered)
 			.then(() => onrender());
 	}, carta.rendererDebounce ?? 300);
 
@@ -68,6 +66,12 @@
 		if (elem) carta.$setRenderer(elem);
 		mounted = true;
 	});
+
+	function render(div: HTMLDivElement) {
+		$effect(() => {
+			innerHTML(div, renderedHtml, { executeScripts: false, disableMutationObserver: true })
+		})
+	}
 </script>
 
 <div
@@ -76,8 +80,7 @@
 	bind:this={elem}
 	{onscroll}
 >
-	<!-- eslint-disable-next-line svelte/no-at-html-tags -->
-	{@html renderedHtml}
+	<div style="display:contents" use:render></div>
 	{#if mounted}
 		{@render children?.()}
 	{/if}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -219,6 +219,9 @@ importers:
       diff:
         specifier: ^5.2.0
         version: 5.2.0
+      diffhtml:
+        specifier: 1.0.0-beta.30
+        version: 1.0.0-beta.30
       esm-env:
         specifier: ^1.0.0
         version: 1.0.0
@@ -2220,6 +2223,9 @@ packages:
   diff@5.2.0:
     resolution: {integrity: sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==}
     engines: {node: '>=0.3.1'}
+
+  diffhtml@1.0.0-beta.30:
+    resolution: {integrity: sha512-yrBteaq309reltj+kAnGqsnpJyQSqmCkd5LAJNAcWNmlgvu+PbiUm9bNxdRYi21BQsQsljTxrjs+AWeeHHghWA==}
 
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
@@ -7096,6 +7102,8 @@ snapshots:
     optional: true
 
   diff@5.2.0: {}
+
+  diffhtml@1.0.0-beta.30: {}
 
   dir-glob@3.0.1:
     dependencies:


### PR DESCRIPTION
Uses [diffhtml](https://diffhtml.org/) to patch the rendered HTML to prevent img, video, and iframe content being re-loaded on every edit.

Closes #162 